### PR TITLE
Updating requests package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django>=1.9.6
 
 # Additional requirements go here
-requests==2.11.1
+requests>=2.11.1
 iso8601==0.1.11
 git+https://github.com/getsentry/responses.git#egg=responses
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'requests==2.11.1',
+        'requests>=2.11.1',
         'iso8601==0.1.11',
         'six==1.10.0',
     ],


### PR DESCRIPTION
It seems that using requests>=2.11.1 is more appropriate to integrate with other software using newer versions of python requests.