### PR TITLE
Resolves #11

### DIFF
--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -19,5 +19,5 @@ from django.contrib import admin
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'', include('wordpress.urls', namespace='wordpress')),
+    url(r'', include('wordpress_api.urls', namespace='wordpress')),
 ]


### PR DESCRIPTION
Correcting the `example` app using (your documentation)[https://django-wordpress-api.readthedocs.io/en/latest/integration.html] which details that the `include` here should be for `wordpress_api.urls` (and not ~~`wordpress.urls`~~). See report in issue #11.